### PR TITLE
fix: improve auto installer to short-circuit on empty package arrays (Fixes #55)

### DIFF
--- a/packages/core/src/lib/auto-installer.spec.ts
+++ b/packages/core/src/lib/auto-installer.spec.ts
@@ -264,9 +264,10 @@ describe('auto-installer', () => {
       it('should handle empty package list', () => {
         installPackages([]);
 
-        expect(execSync).toHaveBeenCalledWith('pnpm add -D ', {
-          stdio: 'inherit',
-        });
+        expect(execSync).not.toHaveBeenCalledWith(
+          expect.stringContaining('add'),
+          expect.any(Object)
+        );
       });
     });
   });

--- a/packages/core/src/lib/auto-installer.ts
+++ b/packages/core/src/lib/auto-installer.ts
@@ -27,6 +27,8 @@ export function installPackages(
   pkgs: string[],
   opts?: { dev?: boolean }
 ): void {
+  if (pkgs.length === 0) return;
+
   const pm = detectPackageManager();
   const dev = opts?.dev ?? true;
   const devFlag = dev ? (pm === 'yarn' ? '-D' : '--save-dev') : '';


### PR DESCRIPTION
## Summary
- Improves the `installPackages()` function to short-circuit early when passed empty arrays
- Prevents building and executing empty commands like `pnpm add -D ` (with trailing space)
- Updates the corresponding test to verify the new no-op behavior

## Changes Made
- Added early return in `installPackages()` when `pkgs.length === 0`
- Modified test expectation from executing empty commands to no-op behavior
- All tests pass with the new implementation

## Test Plan
- [x] All existing tests pass
- [x] Modified test verifies no command execution for empty arrays  
- [x] Function maintains backward compatibility for non-empty arrays
- [x] Works correctly with all package managers (pnpm, yarn, npm)

🤖 Generated with [Claude Code](https://claude.ai/code)